### PR TITLE
Fix INVALID tree item bug

### DIFF
--- a/src/issueProvider.ts
+++ b/src/issueProvider.ts
@@ -35,6 +35,7 @@ export class IssueProvider implements vscode.TreeDataProvider<Issue> {
                 c.issueId = c.number;
                 c.assignee = c.assignee === null ? 'Nobody' : c.assignee;
                 c.creator = c.user.login;
+                c.id = c.id.toString();
             });
             page++;
             if (issuesOfPage.length < 10) {


### PR DESCRIPTION
Fix https://github.com/IJustDev/Gitea-VSCode/issues/48 - convert Issue.id to string when generating TreeItems. 