### PR TITLE
Updated VSCode Extension to non depraciated ones

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin"
+        "yzhang.markdown-all-in-one",
+        "dbaeumer.vscode-eslint",
+        "ms-vscode.vscode-typescript-next"
 	]
 }


### PR DESCRIPTION
TSLint extension is deprecated as it is no longer being maintained, i added some recomendations more fitted and updated for the project.