### PR TITLE
Added Alternative connection method using https library for Local Gitea Server without SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Otherwise do not push the .vscode folder to your repository and doublecheck this
     , "gitea.owner": "%OWNER%"
     , "gitea.repo": "%REPO_NAME%"
 ```
+- If your Gitea instance is on local network server then there are chances of Error 401 or 400 due to ssl/tls certificate issue is not being able to handled by the default Axios library method. In that case use following instead of above snippet.
+```
+    , "gitea.havingCertificateIssueOnLocalServer": true
+    , "gitea.host": %YOUR_GITEA_HOST% // Example: "192.168.0.99" (with quotes, without http or https)
+    , "gitea.port": %YOUR_GITEA_EXPOSED_PORT% // Gitea Remote Exposed Port. Example: 3100 (without quotes)
+    , "gitea.owner": "%OWNER%"
+    , "gitea.repo": "%REPO_NAME%"
+    , "gitea.sslVerify": false
+```
 
 ### The following details are needed
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,28 @@
                     "description": "The remote gitea instance's url. Append base url to this string eg. http://localhost:8080 or http://localhost/gitea",
                     "pattern": "^(https|http)://"
                 },
+                "gitea.havingCertificateIssueOnLocalServer": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "true=Try alternative connection method using https library which bypass tls certification issue on local server, false=Use default AXIOS method'."
+                },
+                "gitea.host": {
+                    "scope": "resource",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "example.com",
+                        "192.168.0.99"
+                    ],
+                    "description": "The remote gitea instance's url without https or http"
+                },
+                "gitea.port": {
+                    "scope": "resource",
+                    "type": "number",
+                    "default": 3100,
+                    "description": "The remote gitea instance's exposing port"
+                },
                 "gitea.owner": {
                     "scope": "resource",
                     "type": "string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,7 +127,11 @@ export class Config2 implements ConfigTypes2 {
         return workspace.getConfiguration('gitea', null);
     }
 
-    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number'): ConfigStorage2[T] {
+    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number', acceptDetault = false): ConfigStorage2[T] {
+        if (!acceptDetault && !this.storage.has(configKey)) {
+            window.showErrorMessage("Gitea-VSCode didn't find a required configuration value: " + configKey);
+            throw new Error(`Failed to load configuration: "${configKey}"`);
+        }
 
         const value = this.storage.has(configKey)
             ? (this.storage.get(configKey) as ConfigStorage2[T])

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,9 @@ import { workspace, window } from 'vscode';
 interface ConfigStorage {
     token: string;
     instanceURL: string;
+    havingCertificateIssueOnLocalServer: boolean;
+    host: string;
+    port: number;
     owner: string;
     repo: string;
     sslVerify: boolean;
@@ -13,6 +16,7 @@ interface ConfigStorage {
 
 export interface ConfigTypes extends ConfigStorage {
     readonly repoApiUrl: string;
+    readonly endPointPath: string;
 }
 
 export class Config implements ConfigTypes {
@@ -50,8 +54,24 @@ export class Config implements ConfigTypes {
         this.storage.update('instanceURL', value);
     }
 
+    public set host(value: string) {
+        this.storage.update('host', value);
+    }
+
+    public set port(value: number) {
+        this.storage.update('port', value);
+    }
+
     public get instanceURL(): any {
         return this.loadConfigValue('instanceURL', 'string');
+    }
+
+    public get host(): any {
+        return this.loadConfigValue('host', 'string');
+    }
+
+    public get port(): any {
+        return this.loadConfigValue('port', 'number');
     }
 
     public get baseURL(): string {
@@ -83,6 +103,20 @@ export class Config implements ConfigTypes {
             '/api/v1/repos/' +
             this.owner +
             '/' + this.repo + '/issues';
+    }
+
+    public get endPointPath(): string {
+        return '/api/v1/repos/' +
+            this.owner +
+            '/' + this.repo + '/issues';
+    }
+    
+    public set havingCertificateIssueOnLocalServer(value) {
+        this.storage.update('havingCertificateIssueOnLocalServer', value);
+    }
+    
+    public get havingCertificateIssueOnLocalServer() {
+        return this.loadConfigValue('havingCertificateIssueOnLocalServer', 'boolean');
     }
 
     public set sslVerify(value) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,9 @@ import { workspace, window } from 'vscode';
 interface ConfigStorage {
     token: string;
     instanceURL: string;
+    havingCertificateIssueOnLocalServer: boolean;
+    host: string;
+    port: number;
     owner: string;
     repo: string;
     sslVerify: boolean;
@@ -11,19 +14,8 @@ interface ConfigStorage {
     debug: boolean;
 }
 
-interface ConfigStorage2 {
-    havingCertificateIssueOnLocalServer: boolean;
-    host: string;
-    port: number;
-    owner: string;
-    repo: string;
-}
-
 export interface ConfigTypes extends ConfigStorage {
     readonly repoApiUrl: string;
-}
-
-export interface ConfigTypes2 extends ConfigStorage2 {
     readonly endPointPath: string;
 }
 
@@ -62,8 +54,24 @@ export class Config implements ConfigTypes {
         this.storage.update('instanceURL', value);
     }
 
+    public set host(value: string) {
+        this.storage.update('host', value);
+    }
+
+    public set port(value: number) {
+        this.storage.update('port', value);
+    }
+
     public get instanceURL(): any {
         return this.loadConfigValue('instanceURL', 'string');
+    }
+
+    public get host(): any {
+        return this.loadConfigValue('host', 'string');
+    }
+
+    public get port(): any {
+        return this.loadConfigValue('port', 'number');
     }
 
     public get baseURL(): string {
@@ -97,6 +105,20 @@ export class Config implements ConfigTypes {
             '/' + this.repo + '/issues';
     }
 
+    public get endPointPath(): string {
+        return '/api/v1/repos/' +
+            this.owner +
+            '/' + this.repo + '/issues';
+    }
+    
+    public set havingCertificateIssueOnLocalServer(value) {
+        this.storage.update('havingCertificateIssueOnLocalServer', value);
+    }
+    
+    public get havingCertificateIssueOnLocalServer() {
+        return this.loadConfigValue('havingCertificateIssueOnLocalServer', 'boolean');
+    }
+
     public set sslVerify(value) {
         this.storage.update('sslVerify', value);
     }
@@ -104,6 +126,7 @@ export class Config implements ConfigTypes {
     public get sslVerify() {
         return this.loadConfigValue('sslVerify', 'boolean');
     }
+
 
     public get render() {
         return this.loadConfigValue('render', 'string')
@@ -119,67 +142,5 @@ export class Config implements ConfigTypes {
 
     public get debug(): boolean {
         return this.loadConfigValue('debug', 'boolean');
-    }
-}
-
-export class Config2 implements ConfigTypes2 {
-    private get storage() {
-        return workspace.getConfiguration('gitea', null);
-    }
-
-    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number', acceptDetault = false): ConfigStorage2[T] {
-        if (!acceptDetault && !this.storage.has(configKey)) {
-            window.showErrorMessage("Gitea-VSCode didn't find a required configuration value: " + configKey);
-            throw new Error(`Failed to load configuration: "${configKey}"`);
-        }
-
-        const value = this.storage.has(configKey)
-            ? (this.storage.get(configKey) as ConfigStorage2[T])
-            : (this.storage.inspect(configKey) as { defaultValue: ConfigStorage2[T]; key: string }).defaultValue;
-
-        if (typeof value === type && (type !== 'string' || (value as string).length > 0)) {
-            return value as ConfigStorage2[T];
-        }
-
-        window.showErrorMessage('Gitea-VSCode failed to load a configuration value that is needed: ' + configKey);
-        throw new Error(`Failed to load configuration: "gitea.${configKey}"`);
-    }
-
-    public set host(value: string) {
-        this.storage.update('host', value);
-    }
-    
-    public get host(): any {
-        return this.loadConfigValue('host', 'string');
-    }
-
-    public set port(value: number) {
-        this.storage.update('port', value);
-    }
-    
-    public get port(): any {
-        return this.loadConfigValue('port', 'number');
-    }
-
-    public get owner() {
-        return this.loadConfigValue('owner', 'string');
-    }
-
-    public get repo() {
-        return this.loadConfigValue('repo', 'string');
-    }
-
-    public get endPointPath(): string {
-        return '/api/v1/repos/' +
-            this.owner +
-            '/' + this.repo + '/issues';
-    }
-    
-    public set havingCertificateIssueOnLocalServer(value) {
-        this.storage.update('havingCertificateIssueOnLocalServer', value);
-    }
-    
-    public get havingCertificateIssueOnLocalServer() {
-        return this.loadConfigValue('havingCertificateIssueOnLocalServer', 'boolean');
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,11 +127,7 @@ export class Config2 implements ConfigTypes2 {
         return workspace.getConfiguration('gitea', null);
     }
 
-    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number', acceptDetault = false): ConfigStorage2[T] {
-        if (!acceptDetault && !this.storage.has(configKey)) {
-            window.showErrorMessage("Gitea-VSCode didn't find a required configuration value: " + configKey);
-            throw new Error(`Failed to load configuration: "${configKey}"`);
-        }
+    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number'): ConfigStorage2[T] {
 
         const value = this.storage.has(configKey)
             ? (this.storage.get(configKey) as ConfigStorage2[T])

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,6 @@ import { workspace, window } from 'vscode';
 interface ConfigStorage {
     token: string;
     instanceURL: string;
-    havingCertificateIssueOnLocalServer: boolean;
-    host: string;
-    port: number;
     owner: string;
     repo: string;
     sslVerify: boolean;
@@ -14,8 +11,19 @@ interface ConfigStorage {
     debug: boolean;
 }
 
+interface ConfigStorage2 {
+    havingCertificateIssueOnLocalServer: boolean;
+    host: string;
+    port: number;
+    owner: string;
+    repo: string;
+}
+
 export interface ConfigTypes extends ConfigStorage {
     readonly repoApiUrl: string;
+}
+
+export interface ConfigTypes2 extends ConfigStorage2 {
     readonly endPointPath: string;
 }
 
@@ -54,24 +62,8 @@ export class Config implements ConfigTypes {
         this.storage.update('instanceURL', value);
     }
 
-    public set host(value: string) {
-        this.storage.update('host', value);
-    }
-
-    public set port(value: number) {
-        this.storage.update('port', value);
-    }
-
     public get instanceURL(): any {
         return this.loadConfigValue('instanceURL', 'string');
-    }
-
-    public get host(): any {
-        return this.loadConfigValue('host', 'string');
-    }
-
-    public get port(): any {
-        return this.loadConfigValue('port', 'number');
     }
 
     public get baseURL(): string {
@@ -105,20 +97,6 @@ export class Config implements ConfigTypes {
             '/' + this.repo + '/issues';
     }
 
-    public get endPointPath(): string {
-        return '/api/v1/repos/' +
-            this.owner +
-            '/' + this.repo + '/issues';
-    }
-    
-    public set havingCertificateIssueOnLocalServer(value) {
-        this.storage.update('havingCertificateIssueOnLocalServer', value);
-    }
-    
-    public get havingCertificateIssueOnLocalServer() {
-        return this.loadConfigValue('havingCertificateIssueOnLocalServer', 'boolean');
-    }
-
     public set sslVerify(value) {
         this.storage.update('sslVerify', value);
     }
@@ -126,7 +104,6 @@ export class Config implements ConfigTypes {
     public get sslVerify() {
         return this.loadConfigValue('sslVerify', 'boolean');
     }
-
 
     public get render() {
         return this.loadConfigValue('render', 'string')
@@ -142,5 +119,67 @@ export class Config implements ConfigTypes {
 
     public get debug(): boolean {
         return this.loadConfigValue('debug', 'boolean');
+    }
+}
+
+export class Config2 implements ConfigTypes2 {
+    private get storage() {
+        return workspace.getConfiguration('gitea', null);
+    }
+
+    private loadConfigValue<T extends keyof ConfigStorage2>(configKey: T, type: 'string' | 'boolean' | 'number', acceptDetault = false): ConfigStorage2[T] {
+        if (!acceptDetault && !this.storage.has(configKey)) {
+            window.showErrorMessage("Gitea-VSCode didn't find a required configuration value: " + configKey);
+            throw new Error(`Failed to load configuration: "${configKey}"`);
+        }
+
+        const value = this.storage.has(configKey)
+            ? (this.storage.get(configKey) as ConfigStorage2[T])
+            : (this.storage.inspect(configKey) as { defaultValue: ConfigStorage2[T]; key: string }).defaultValue;
+
+        if (typeof value === type && (type !== 'string' || (value as string).length > 0)) {
+            return value as ConfigStorage2[T];
+        }
+
+        window.showErrorMessage('Gitea-VSCode failed to load a configuration value that is needed: ' + configKey);
+        throw new Error(`Failed to load configuration: "gitea.${configKey}"`);
+    }
+
+    public set host(value: string) {
+        this.storage.update('host', value);
+    }
+    
+    public get host(): any {
+        return this.loadConfigValue('host', 'string');
+    }
+
+    public set port(value: number) {
+        this.storage.update('port', value);
+    }
+    
+    public get port(): any {
+        return this.loadConfigValue('port', 'number');
+    }
+
+    public get owner() {
+        return this.loadConfigValue('owner', 'string');
+    }
+
+    public get repo() {
+        return this.loadConfigValue('repo', 'string');
+    }
+
+    public get endPointPath(): string {
+        return '/api/v1/repos/' +
+            this.owner +
+            '/' + this.repo + '/issues';
+    }
+    
+    public set havingCertificateIssueOnLocalServer(value) {
+        this.storage.update('havingCertificateIssueOnLocalServer', value);
+    }
+    
+    public get havingCertificateIssueOnLocalServer() {
+        return this.loadConfigValue('havingCertificateIssueOnLocalServer', 'boolean');
     }
 }

--- a/src/giteaConnector.ts
+++ b/src/giteaConnector.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import { IGiteaResponse } from './IGiteaResponse';
 import { Logger } from './logger';
-import { Config } from './config';
+import { Config2 } from './config';
 
 export class GiteaConnector {
     private authToken: string;
@@ -16,8 +16,8 @@ export class GiteaConnector {
     }
 
     public async getIssues(repoUri: string, state: string, page: number = 0): Promise<IGiteaResponse> {
-        const config = new Config();
-        return config.havingCertificateIssueOnLocalServer ?
+        const config2 = new Config2();
+        return config2.havingCertificateIssueOnLocalServer ?
         this.getEndpoint2(`${repoUri}?state=${state}&page=${page}`):
         this.getEndpoint(`${repoUri}?state=${state}&page=${page}`);
     }
@@ -39,7 +39,7 @@ export class GiteaConnector {
 
     /// Using https library because of self-signed certificates issue  in axios, this issue was occurring  when using axios with local gitea server running on docker
     private async getEndpoint2(endPointPath: string): Promise<IGiteaResponse> {
-        const config = new Config();
+        const config2 = new Config2();
         Logger.debug('getEndpoint', 'request', { 'url': endPointPath });
 
         return new Promise<IGiteaResponse>(async (resolve, reject) => {
@@ -54,7 +54,7 @@ export class GiteaConnector {
                     const responseDataString = Buffer.concat(responseData).toString(); // Join chunks into a single string
                     const response: IGiteaResponse = { data: JSON.parse(responseDataString) }; // Parse the JSON data
                     resolve(response);
-                    Logger.debug('getEndpoint', 'response', { 'url': config.host+ ':' + config.port + endPointPath, 'status': res.statusCode,'size': response.data.length });
+                    Logger.debug('getEndpoint', 'response', { 'url': config2.host+ ':' + config2.port + endPointPath, 'status': res.statusCode,'size': response.data.length });
                 });
             }).on('error', (err) => {
                 this.displayErrorMessage(err.message);
@@ -84,11 +84,11 @@ export class GiteaConnector {
 
     /// Returns alternative request options for [getEndpoint2] method written above
     private requestOptions2(endPointPath:string): object {
-        const config = new Config();
+        const config2 = new Config2();
         return {
             method: 'GET',
-            hostname: config.host,
-            port: config.port,
+            hostname: config2.host,
+            port: config2.port,
             path: endPointPath,
             
             rejectUnauthorized: this.ssl,

--- a/src/giteaConnector.ts
+++ b/src/giteaConnector.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import { IGiteaResponse } from './IGiteaResponse';
 import { Logger } from './logger';
-import { Config2 } from './config';
+import { Config } from './config';
 
 export class GiteaConnector {
     private authToken: string;
@@ -16,8 +16,8 @@ export class GiteaConnector {
     }
 
     public async getIssues(repoUri: string, state: string, page: number = 0): Promise<IGiteaResponse> {
-        const config2 = new Config2();
-        return config2.havingCertificateIssueOnLocalServer ?
+        const config = new Config();
+        return config.havingCertificateIssueOnLocalServer ?
         this.getEndpoint2(`${repoUri}?state=${state}&page=${page}`):
         this.getEndpoint(`${repoUri}?state=${state}&page=${page}`);
     }
@@ -39,7 +39,7 @@ export class GiteaConnector {
 
     /// Using https library because of self-signed certificates issue  in axios, this issue was occurring  when using axios with local gitea server running on docker
     private async getEndpoint2(endPointPath: string): Promise<IGiteaResponse> {
-        const config2 = new Config2();
+        const config = new Config();
         Logger.debug('getEndpoint', 'request', { 'url': endPointPath });
 
         return new Promise<IGiteaResponse>(async (resolve, reject) => {
@@ -54,7 +54,7 @@ export class GiteaConnector {
                     const responseDataString = Buffer.concat(responseData).toString(); // Join chunks into a single string
                     const response: IGiteaResponse = { data: JSON.parse(responseDataString) }; // Parse the JSON data
                     resolve(response);
-                    Logger.debug('getEndpoint', 'response', { 'url': config2.host+ ':' + config2.port + endPointPath, 'status': res.statusCode,'size': response.data.length });
+                    Logger.debug('getEndpoint', 'response', { 'url': config.host+ ':' + config.port + endPointPath, 'status': res.statusCode,'size': response.data.length });
                 });
             }).on('error', (err) => {
                 this.displayErrorMessage(err.message);
@@ -84,11 +84,11 @@ export class GiteaConnector {
 
     /// Returns alternative request options for [getEndpoint2] method written above
     private requestOptions2(endPointPath:string): object {
-        const config2 = new Config2();
+        const config = new Config();
         return {
             method: 'GET',
-            hostname: config2.host,
-            port: config2.port,
+            hostname: config.host,
+            port: config.port,
             path: endPointPath,
             
             rejectUnauthorized: this.ssl,

--- a/src/giteaConnector.ts
+++ b/src/giteaConnector.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 import { IGiteaResponse } from './IGiteaResponse';
 import { Logger } from './logger';
+import { Config } from './config';
 
 export class GiteaConnector {
     private authToken: string;
@@ -15,9 +16,13 @@ export class GiteaConnector {
     }
 
     public async getIssues(repoUri: string, state: string, page: number = 0): Promise<IGiteaResponse> {
-        return this.getEndpoint(`${repoUri}?state=${state}&page=${page}`);
+        const config = new Config();
+        return config.havingCertificateIssueOnLocalServer ?
+        this.getEndpoint2(`${repoUri}?state=${state}&page=${page}`):
+        this.getEndpoint(`${repoUri}?state=${state}&page=${page}`);
     }
 
+    /// Using AXIOS
     private async getEndpoint(url: string): Promise<IGiteaResponse> {
         Logger.debug('getEndpoint', 'request', {'url': url})
         return new Promise<IGiteaResponse>((resolve, reject) => {
@@ -29,6 +34,35 @@ export class GiteaConnector {
                 Logger.log(err)
                 reject(err);
             });
+        });
+    }
+
+    /// Using https library because of self-signed certificates issue  in axios, this issue was occurring  when using axios with local gitea server running on docker
+    private async getEndpoint2(endPointPath: string): Promise<IGiteaResponse> {
+        const config = new Config();
+        Logger.debug('getEndpoint', 'request', { 'url': endPointPath });
+
+        return new Promise<IGiteaResponse>(async (resolve, reject) => {
+            const responseData: Buffer[] = []; // Initialize as an empty array
+
+            const req = https.request(this.requestOptions2(endPointPath), (res) => {
+                res.on('data', (chunk) => {
+                    responseData.push(chunk); // Push each chunk to the array
+                });
+
+                res.on('end', () => {
+                    const responseDataString = Buffer.concat(responseData).toString(); // Join chunks into a single string
+                    const response: IGiteaResponse = { data: JSON.parse(responseDataString) }; // Parse the JSON data
+                    resolve(response);
+                    Logger.debug('getEndpoint', 'response', { 'url': config.host+ ':' + config.port + endPointPath, 'status': res.statusCode,'size': response.data.length });
+                });
+            }).on('error', (err) => {
+                this.displayErrorMessage(err.message);
+                Logger.log(err.message);
+                reject(err);
+            });
+
+            req.end();
         });
     }
 
@@ -48,6 +82,22 @@ export class GiteaConnector {
         };
     }
 
+    /// Returns alternative request options for [getEndpoint2] method written above
+    private requestOptions2(endPointPath:string): object {
+        const config = new Config();
+        return {
+            method: 'GET',
+            hostname: config.host,
+            port: config.port,
+            path: endPointPath,
+            
+            rejectUnauthorized: this.ssl,
+            headers: {
+                Authorization: 'token ' + this.authToken,
+                Accept: 'application/json;charset=utf-8'
+            },
+        };
+    }
     private displayErrorMessage(err: string) {
         vscode.window.showErrorMessage("Error occoured. " + err);
     }

--- a/src/issueProvider.ts
+++ b/src/issueProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 
 import { Issue } from './issue';
 import { Config } from './config';
-import { Config2 } from './config';
 import { GiteaConnector } from './giteaConnector';
 import { Logger } from './logger';
 
@@ -25,14 +24,13 @@ export class IssueProvider implements vscode.TreeDataProvider<Issue> {
     public async getIssuesAsync() : Promise<Issue[]> {
         this.issueList = [];
         const config = new Config();
-        const config2 = new Config2();
         const giteaConnector = new GiteaConnector(config.token, config.sslVerify);
 
         const issues = [];
         let page = 1;
         while (page < 11) {
             Logger.log( `Retrieve issues. State: ${this.state} - page ${page}`);
-            const issuesOfPage = (await giteaConnector.getIssues(config2.havingCertificateIssueOnLocalServer ? config2.endPointPath : config.repoApiUrl, this.state, page)).data;
+            const issuesOfPage = (await giteaConnector.getIssues(config.havingCertificateIssueOnLocalServer ? config.endPointPath : config.repoApiUrl, this.state, page)).data;
             Logger.log( `${issuesOfPage.length} issues retrieved (state: ${this.state} - page: ${page})`);
             issues.push(...issuesOfPage);
             issuesOfPage.forEach((c) => {

--- a/src/issueProvider.ts
+++ b/src/issueProvider.ts
@@ -30,7 +30,7 @@ export class IssueProvider implements vscode.TreeDataProvider<Issue> {
         let page = 1;
         while (page < 11) {
             Logger.log( `Retrieve issues. State: ${this.state} - page ${page}`);
-            const issuesOfPage = (await giteaConnector.getIssues(config.repoApiUrl, this.state, page)).data;
+            const issuesOfPage = (await giteaConnector.getIssues(config.havingCertificateIssueOnLocalServer ? config.endPointPath : config.repoApiUrl, this.state, page)).data;
             Logger.log( `${issuesOfPage.length} issues retrieved (state: ${this.state} - page: ${page})`);
             issues.push(...issuesOfPage);
             issuesOfPage.forEach((c) => {

--- a/src/issueProvider.ts
+++ b/src/issueProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { Issue } from './issue';
 import { Config } from './config';
+import { Config2 } from './config';
 import { GiteaConnector } from './giteaConnector';
 import { Logger } from './logger';
 
@@ -24,13 +25,14 @@ export class IssueProvider implements vscode.TreeDataProvider<Issue> {
     public async getIssuesAsync() : Promise<Issue[]> {
         this.issueList = [];
         const config = new Config();
+        const config2 = new Config2();
         const giteaConnector = new GiteaConnector(config.token, config.sslVerify);
 
         const issues = [];
         let page = 1;
         while (page < 11) {
             Logger.log( `Retrieve issues. State: ${this.state} - page ${page}`);
-            const issuesOfPage = (await giteaConnector.getIssues(config.havingCertificateIssueOnLocalServer ? config.endPointPath : config.repoApiUrl, this.state, page)).data;
+            const issuesOfPage = (await giteaConnector.getIssues(config2.havingCertificateIssueOnLocalServer ? config2.endPointPath : config.repoApiUrl, this.state, page)).data;
             Logger.log( `${issuesOfPage.length} issues retrieved (state: ${this.state} - page: ${page})`);
             issues.push(...issuesOfPage);
             issuesOfPage.forEach((c) => {


### PR DESCRIPTION
- Added 3 config options: `havingCertificateIssueOnLocalServer`, `host`, `port`
- Added a method to connect using https library based on config value
- Added another request option specifically for the new getEndpoint2 method
- Updated `readme.md` with newly added `havingCertificateIssueOnLocalServer`, `host`, `port`